### PR TITLE
フロント実装　購入内容の確認ページ

### DIFF
--- a/app/assets/stylesheets/buyconfirmation.css.scss
+++ b/app/assets/stylesheets/buyconfirmation.css.scss
@@ -1,0 +1,148 @@
+.single-main {
+  display: block;
+  .buyconfirmation-container {
+    width: 600px;
+    margin: 0 auto;
+    background: #fff;
+    .buyconfirmation-head {
+      padding: 40px 64px;
+      font-size: 20px;
+      line-height: 1.5;
+      text-align: center;
+      font-weight: bold;
+      border-bottom: 1px solid#f5f5f5;
+    }
+    .content-item {
+      padding: 5px 64px;
+      line-height: 1.5;
+      border-bottom: 1px solid#f5f5f5;
+      .buyform-group{
+        padding-top: 10px;
+        padding-bottom: 10px;
+        .item {
+          width: 100%;
+          margin: 8px 0 0;
+          height: 120px;
+          background: #fff;
+          display: flex;
+          .item-image {
+            background-color: #3ccACE;
+            min-width: 100px;
+            height: 100%;
+          }
+          .item-detail {
+            margin-left: 15px;
+          }
+          .item-text {
+          }
+          .item-price {
+            font-weight: bold;
+          }
+          .item-fee {
+            font-weight: bold;
+          }
+        }
+      }
+    }
+
+    .content-payment {
+      padding: 5px 64px;
+      line-height: 1.5;
+      text-align: center;
+      border-bottom: 1px solid#f5f5f5;
+      .buyform-group{
+        padding-top: 10px;
+        padding-bottom: 10px;
+        .payment {
+          width: 100%;
+          margin: 8px 0 0;
+          height: 120px;
+          background: #fff;
+          display: flex;
+          align-items: center;
+          justify-content: space-between;
+          &__text {
+            font-size: 23px;
+          }
+          &__price {
+            font-size: 35px;
+          }
+        }
+      }
+    }
+
+    .content-creditcard {
+      padding: 5px 64px;
+      line-height: 1.5;
+      border-bottom: 1px solid#f5f5f5;
+      .buyform-group{
+        padding-top: 10px;
+        padding-bottom: 10px;
+        .paymentmethod {
+        width: 100%;
+        height: 150px;
+        font-size: 16px;
+          .creditcard {
+            width: 100%;
+            height: 80%;
+            background-color: #3ccACE;
+          }
+        }
+      }
+    }
+
+    .content-shipping {
+      padding: 5px 64px;
+      line-height: 1.5;
+      border-bottom: 1px solid#f5f5f5;
+      .buyform-group{
+        padding-top: 10px;
+        padding-bottom: 10px;
+        .shipping {
+          width: 100%;
+          height: 150px;
+          font-size: 16px;
+            .shipping-address {
+              width: 100%;
+              height: 80%;
+              background-color:#3ccACE;
+            }
+          }
+        }
+      }
+    
+    .content-buybtn {
+      padding: 5px 64px;
+      line-height: 1.5;
+      border-bottom: 1px solid#f5f5f5;
+      .buyform-group{
+        padding-top: 10px;
+        padding-bottom: 10px;
+        .btn-buy {
+          width: 100%;
+          height: 250px;
+          .btn {
+            margin: 0 auto;
+            background: #3ccACE;
+            border: 1px solid #3ccACE;
+            color: #fff;
+            display: block;
+            width: 100%;
+            height: 48px;
+            line-height: 48px;
+            font-size: 14px;
+            transition: all ease-out .3s;
+            cursor: pointer;
+            text-align: center;
+            a{
+              color:white;
+            }
+          }
+          .install-message {
+            margin-top: 40px;
+          }
+        }
+      }
+    }
+  }
+}

--- a/app/views/items/buy-confirm.html.haml
+++ b/app/views/items/buy-confirm.html.haml
@@ -1,0 +1,66 @@
+.single-container
+  .single-header
+    %h1
+      .single-container__header-icon
+        = link_to "#" do
+          .single-container__header-icon-image
+            = image_tag 'logo.png', size: '300x60'
+  
+  .single-main
+    .buyconfirmation-container
+      %h2.buyconfirmation-head
+        購入内容の確認
+      .content-item
+        .buyform-group
+          .item
+            .item-image
+            .item-detail
+              %p.item-text
+                ルイヴィトンのバッグ・コーチの財布・グッチのバッグ・エルメスのスカーフ・ナイキのスニーカー・アディダスのパーカー・プーマのトレーナー・アンダーアーマーのシャツ
+              %p.item-pricefee
+              %span.item-price
+                ¥ 35,000
+              %span.item-fee
+                （税込）送料込み
+      .content-payment
+        .buyform-group
+          .payment
+            .payment__text
+              支払い金額
+            .payment__price
+              ¥ 35,000
+      .content-creditcard
+        .buyform-group
+          .paymentmethod
+            クレジットカード情報
+            .creditcard
+              クレジットカードの情報だよ
+              .br
+              クレジットカードの情報の取り出し方によってクラスを追加する
+      .content-shipping
+        .buyform-group
+          .shipping
+            配送先
+            .shipping-address
+              住所だよ
+      .content-buybtn
+        .buyform-group
+          .btn-buy
+            .btn
+              購入する
+            .install-message
+              アプリをお持ちでない方は以下よりインストールしてご利用いただけます。
+            .appimage
+              AppStoreとGooglePlayのアイコン
+      
+  .single-footer
+    .navigation
+      %ul.clearfix
+        %li 
+          %a{href: "#"} プライバシーポリシー
+        %li 
+          %a{href: "#"} フリマ利用規約
+        %li 
+          %a{href: "#"} 特定商取引に関する表記
+      = link_to "#" do
+        = image_tag 'logo.png', size: '300x60', class: "footer-logo"

--- a/app/views/items/buy-confirm.html.haml
+++ b/app/views/items/buy-confirm.html.haml
@@ -57,10 +57,13 @@
     .navigation
       %ul.clearfix
         %li 
-          %a{href: "#"} プライバシーポリシー
+          = link_to "#" do
+            プライバシーポリシー
         %li 
-          %a{href: "#"} フリマ利用規約
+          = link_to "#" do
+            フリマ利用規約
         %li 
-          %a{href: "#"} 特定商取引に関する表記
+          = link_to "#" do 
+            特定商取引に関する表記
       = link_to "#" do
         = image_tag 'logo.png', size: '300x60', class: "footer-logo"


### PR DESCRIPTION
What
購入内容の確認ページの実装

Why
購入内容の確認の際に必要なページのため

<img width="1438" alt="スクリーンショット 2020-02-04 17 06 48" src="https://user-images.githubusercontent.com/59085642/73725953-dcd45180-4771-11ea-974b-ce39ae22250c.png">
<img width="1438" alt="スクリーンショット 2020-02-04 17 06 59" src="https://user-images.githubusercontent.com/59085642/73725970-e1990580-4771-11ea-8898-a188e41e8ed5.png">
